### PR TITLE
Maintain compatibility with Kokkos 5.2+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 kokkos_check( DEVICES ${VERTEXCFD_KOKKOS_DEVICE_TYPE} )
 
 # ensure that we can use lambdas if we are using cuda.
-if(${VERTEXCFD_KOKKOS_DEVICE_TYPE} STREQUAL "CUDA")
+if(${VERTEXCFD_KOKKOS_DEVICE_TYPE} STREQUAL "CUDA" AND Kokkos_VERSION VERSION_LESS 4.1)
   kokkos_check(OPTIONS CUDA_LAMBDA)
 endif()
 


### PR DESCRIPTION
The CUDA_LAMBDA option is deprecated and always ON since Kokkos 4.1 and is scheduled for removal in the (upcoming) Kokkos 5.2 release.